### PR TITLE
Add GitHub Action workflow to regen PDFs

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -1,0 +1,44 @@
+name: Regenerate PDF files
+
+'on':
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  TASK_VERSION: "3.41.0"
+
+jobs:
+  ci:
+    name: Regenerate PDF files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Task
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          curl -sL "https://github.com/go-task/task/releases/download/v${TASK_VERSION}/task_linux_amd64.tar.gz" | tar xzf - -C "${HOME}/.local/bin" task
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install --assume-yes \
+            latexmk \
+            texlive-lang-english \
+            texlive-lang-italian \
+            texlive-latex-recommended \
+            texlive-pictures
+      - name: Regenerate PDFs
+        run: |
+          set -o errexit
+          find . -type f -not -path '*/.*' -name 'main.tex' |
+            while IFS= read -r file; do
+              dirname=$(dirname "$file")
+              echo "::group::Regenerating PDF for ${dirname}"
+              cd "${dirname}"
+              task pdf
+              task clean
+              echo "::endgroup::"
+              cd "${OLDPWD}"
+            done


### PR DESCRIPTION
Continuously regenarate PDF files to exercise possible correctness of LaTeX files.

Relies that each directory with LaTeX files has `main.tex`.