### PR TITLE
Ignore possible .vrb file too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.pdf
 *.snm
 *.toc
+*.vrb


### PR DESCRIPTION
Always possible LaTeX artifacts that should not be committed.
